### PR TITLE
Benchmark bug

### DIFF
--- a/bench/sorted.js
+++ b/bench/sorted.js
@@ -1,4 +1,3 @@
-
 var SortedSet = require("../sorted-set");
 var SortedArraySet = require("../sorted-array-set");
 
@@ -29,7 +28,7 @@ var size = 10000;
 
     function hrtime() {
         var hrtime = process.hrtime();
-        return hrtime[0] * 1000 + hrtime[1] / Math.pow(2, 32);
+        return hrtime[0] * 1e3 + hrtime[1] / 1e6;
     }
 
     function time(callback) {


### PR DESCRIPTION
Hello. You seem have a bug in the [benchmark](https://github.com/montagejs/collections/blob/592ec42395f6334c67af878983b2472cc0dd0eec/bench/sorted.js).

There's a statement

``` js
return hrtime[0] * 1000 + hrtime[1] / Math.pow(2, 32);
```

which is wrong. The [process.hrtime()](http://nodejs.org/api/process.html#process_process_hrtime) returns a `[seconds, nanoseconds]` pair. Nano stands for 10**-9, not 2**-32.
