### PR TITLE
Dict should send a value with MapChange events 

### DIFF
--- a/dict.js
+++ b/dict.js
@@ -62,7 +62,7 @@ Dict.prototype.set = function (key, value) {
         }
         this.store[mangled] = value;
         if (this.dispatchesMapChanges) {
-            this.dispatchMapChange(key, undefined);
+            this.dispatchMapChange(key, value);
         }
         return false;
     } else { // create

--- a/spec/dict.js
+++ b/spec/dict.js
@@ -45,6 +45,15 @@ function describeDict(Dict) {
         expect(dict.delete("__proto__")).toBe(false);
     });
 
+    it("should send a value for MapChange events", function () {
+        var dict = Dict({a: 1});
+
+        var listener = function(value, key) {
+            expect(value).toBe(2);
+        };
+        dict.addMapChangeListener(listener);
+        dict.set('a', 2);
+    })
 }
 
 function shouldHaveTheUsualContent(dict) {


### PR DESCRIPTION
Existing code always sent `undefined` when doing an update on an existing key.
