### PR TITLE
Make List and Set dispatch range changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1226,6 +1226,8 @@ property of a given object.
 
 Goals
 
+- make array dispatch length property changes between range changes to
+  be consistent with List.
 - automate the generation of the method support tables in readme and
   normalize declaration order
 - comprehensive specs and spec coverage tests

--- a/listen/array-changes.js
+++ b/listen/array-changes.js
@@ -77,22 +77,9 @@ var observableArrayProperties = {
     reverse: {
         value: function reverse() {
 
-            // dispatch before change events
-            this.dispatchBeforeRangeChange(this, this, 0);
-            for (var i = 0; i < this.length; i++) {
-                PropertyChanges.dispatchBeforeOwnPropertyChange(this, i, this[i]);
-                this.dispatchBeforeMapChange(i, this[i]);
-            }
-
-            // actual work
-            array_reverse.call(this);
-
-            // dispatch after change events
-            for (var i = 0; i < this.length; i++) {
-                PropertyChanges.dispatchOwnPropertyChange(this, i, this[i]);
-                this.dispatchMapChange(i, this[i]);
-            }
-            this.dispatchRangeChange(this, this, 0);
+            var reversed = this.constructClone(this);
+            reversed.reverse();
+            this.swap(0, this.length, reversed);
 
             return this;
         },

--- a/set.js
+++ b/set.js
@@ -68,15 +68,16 @@ Set.prototype.get = function (value) {
 Set.prototype.add = function (value) {
     var node = new this.order.Node(value);
     if (!this.store.has(node)) {
+        var index = this.length;
         if (this.dispatchesRangeChanges) {
-            this.dispatchBeforeRangeChange([value], [], 0);
+            this.dispatchBeforeRangeChange([value], [], index);
         }
         this.order.add(value);
         node = this.order.head.prev;
         this.store.add(node);
         this.length++;
         if (this.dispatchesRangeChanges) {
-            this.dispatchRangeChange([value], [], 0);
+            this.dispatchRangeChange([value], [], index);
         }
         return true;
     }
@@ -86,15 +87,15 @@ Set.prototype.add = function (value) {
 Set.prototype["delete"] = function (value) {
     var node = new this.order.Node(value);
     if (this.store.has(node)) {
-        if (this.dispatchesRangeChanges) {
-            this.dispatchBeforeRangeChange([], [value], 0);
-        }
         var node = this.store.get(node);
+        if (this.dispatchesRangeChanges) {
+            this.dispatchBeforeRangeChange([], [value], node.index);
+        }
         this.store["delete"](node); // removes from the set
-        node["delete"](); // removes the node from the list in place
+        this.order.splice(node, 1); // removes the node from the list
         this.length--;
         if (this.dispatchesRangeChanges) {
-            this.dispatchRangeChange([], [value], 0);
+            this.dispatchRangeChange([], [value], node.index);
         }
         return true;
     }
@@ -162,5 +163,9 @@ Set.prototype.iterate = function () {
 Set.prototype.log = function () {
     var set = this.store;
     return set.log.apply(set, arguments);
+};
+
+Set.prototype.makeObservable = function () {
+    this.order.makeObservable();
 };
 

--- a/spec/list-spec.js
+++ b/spec/list-spec.js
@@ -2,6 +2,7 @@
 var List = require("../list");
 var describeDequeue = require("./dequeue");
 var describeCollection = require("./collection");
+var describeRangeChanges = require("./listen/range-changes");
 
 describe("List", function () {
     // new List()
@@ -180,6 +181,8 @@ describe("List", function () {
         });
 
     });
+
+    describeRangeChanges(List);
 
 });
 

--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -1,7 +1,11 @@
 
 require("../../listen/array-changes");
+var describeRangeChanges = require("./range-changes");
 
 describe("Array change dispatch", function () {
+
+    // TODO (make consistent with List)
+    // describeRangeChanges(Array.from);
 
     var array = [1, 2, 3];
     var spy;
@@ -253,14 +257,14 @@ describe("Array change dispatch", function () {
         array.reverse();
         expect(array.slice()).toEqual([30, 20, 10]);
         expect(spy.argsForCall).toEqual([
-            ["before content change at", 0, "to add", [10, 20, 30], "to remove", [10, 20, 30]],
+            ["before content change at", 0, "to add", [30, 20, 10], "to remove", [10, 20, 30]],
             ["change at", 0, "from", 10],
             ["change at", 1, "from", 20],
             ["change at", 2, "from", 30],
             ["change at", 0, "to", 30],
             ["change at", 1, "to", 20],
             ["change at", 2, "to", 10],
-            ["content change at", 0, "added", [30, 20, 10], "removed", [30, 20, 10]],
+            ["content change at", 0, "added", [30, 20, 10], "removed", [10, 20, 30]],
         ]);
     });
 

--- a/spec/listen/range-changes.js
+++ b/spec/listen/range-changes.js
@@ -1,0 +1,303 @@
+
+module.exports = describeRangeChanges;
+function describeRangeChanges(Collection) {
+
+    var collection = Collection([1, 2, 3]);
+    var spy;
+
+    // the following tests all share the same initial collection so they
+    // are sensitive to changes in order
+
+    it("set up listeners", function () {
+
+        collection.addBeforeOwnPropertyChangeListener("length", function (length) {
+            spy("length change from", length);
+        });
+
+        collection.addOwnPropertyChangeListener("length", function (length) {
+            spy("length change to", length);
+        });
+
+        collection.addBeforeRangeChangeListener(function (plus, minus, index) {
+            spy("before content change at", index, "to add", plus.slice(), "to remove", minus.slice());
+        });
+
+        collection.addRangeChangeListener(function (plus, minus, index) {
+            spy("content change at", index, "added", plus.slice(), "removed", minus.slice());
+        });
+
+    });
+
+    it("clear initial values", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([1, 2, 3]);
+        collection.clear();
+        expect(collection.slice()).toEqual([]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [], "to remove", [1, 2, 3]],
+            ["length change from", 3],
+            ["length change to", 0],
+            ["content change at", 0, "added", [], "removed", [1, 2, 3]],
+        ]);
+    });
+
+    it("push two values on empty collection", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([]); // initial
+        collection.push(10, 20);
+        expect(collection.slice()).toEqual([10, 20]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [10, 20], "to remove", []],
+            ["length change from", 0],
+            ["length change to", 2],
+            ["content change at", 0, "added", [10, 20], "removed", []],
+        ]);
+
+    });
+
+    it("pop one value", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20]);
+        collection.pop();
+        expect(collection.slice()).toEqual([10]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 1, "to add", [], "to remove", [20]],
+            ["length change from", 2],
+            ["length change to", 1],
+            ["content change at", 1, "added", [], "removed", [20]],
+        ]);
+    });
+
+    it("push two values on top of existing one, with hole open for splice", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10]);
+        collection.push(40, 50);
+        expect(collection.slice()).toEqual([10, 40, 50]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 1, "to add", [40, 50], "to remove", []],
+            ["length change from", 1],
+            ["length change to", 3],
+            ["content change at", 1, "added", [40, 50], "removed", []],
+        ]);
+    });
+
+    it("splices two values into middle", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 40, 50]);
+        expect(collection.splice(1, 0, 20, 30)).toEqual([]);
+        expect(collection.slice()).toEqual([10, 20, 30, 40, 50]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 1, "to add", [20, 30], "to remove", []],
+            ["length change from", 3],
+            ["length change to", 5],
+            ["content change at", 1, "added", [20, 30], "removed", []],
+        ]);
+    });
+
+    it("pushes one value to end", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20, 30, 40, 50]);
+        collection.push(60);
+        expect(collection.slice()).toEqual([10, 20, 30, 40, 50, 60]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 5, "to add", [60], "to remove", []],
+            ["length change from", 5],
+            ["length change to", 6],
+            ["content change at", 5, "added", [60], "removed", []],
+        ]);
+    });
+
+    it("splices in place", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20, 30, 40, 50, 60]);
+        expect(collection.splice(2, 2, "A", "B")).toEqual([30, 40]);
+        expect(collection.slice()).toEqual([10, 20, "A", "B", 50, 60]);
+        expect(spy.argsForCall).toEqual([
+            // no length change
+            ["before content change at", 2, "to add", ["A", "B"], "to remove", [30, 40]],
+            ["content change at", 2, "added", ["A", "B"], "removed", [30, 40]],
+        ]);
+    });
+
+    // ---- fresh start
+
+    it("shifts one from the beginning", function () {
+        collection.clear(); // start over fresh
+        collection.push(10, 20, 30);
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20, 30]);
+        expect(collection.shift()).toEqual(10);
+        expect(collection.slice()).toEqual([20, 30]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [], "to remove", [10]],
+            ["length change from", 3],
+            ["length change to", 2],
+            ["content change at", 0, "added", [], "removed", [10]],
+        ]);
+    });
+
+    it("sets new value at end", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([20, 30]);
+        expect(collection.splice(2, 0, 40)).toEqual([]);
+        expect(collection.slice()).toEqual([20, 30, 40]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 2, "to add", [40], "to remove", []],
+            ["length change from", 2],
+            ["length change to", 3],
+            ["content change at", 2, "added", [40], "removed", []],
+        ]);
+    });
+
+    it("sets new value at beginning", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([20, 30, 40]);
+        expect(collection.splice(0, 1, 10)).toEqual([20]);
+        expect(collection.slice()).toEqual([10, 30, 40]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [10], "to remove", [20]],
+            ["content change at", 0, "added", [10], "removed", [20]],
+        ]);
+    });
+
+    // ---- fresh start
+
+    it("unshifts one to the beginning", function () {
+        collection.clear(); // start over fresh
+        expect(collection.slice()).toEqual([]);
+        spy = jasmine.createSpy();
+        collection.unshift(30);
+        expect(collection.slice()).toEqual([30]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [30], "to remove", []],
+            ["length change from", 0],
+            ["length change to", 1],
+            ["content change at", 0, "added", [30], "removed", []],
+        ]);
+    });
+
+    it("unshifts two values on beginning of already populated collection", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([30]);
+        collection.unshift(10, 20);
+        expect(collection.slice()).toEqual([10, 20, 30]);
+        expect(spy.argsForCall).toEqual([
+            // added and removed values reflect the ending values, not the values at the time of the call
+            ["before content change at", 0, "to add", [10, 20], "to remove", []],
+            ["length change from", 1],
+            ["length change to", 3],
+            ["content change at", 0, "added", [10, 20], "removed", []],
+        ]);
+    });
+
+    it("reverses in place", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20, 30]);
+        collection.reverse();
+        expect(collection.slice()).toEqual([30, 20, 10]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [30, 20, 10], "to remove", [10, 20, 30]],
+            ["content change at", 0, "added", [30, 20, 10], "removed", [10, 20, 30]],
+        ]);
+    });
+
+    it("sorts in place", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([30, 20, 10]);
+        collection.sort();
+        expect(collection.slice()).toEqual([10, 20, 30]);
+        expect(spy.argsForCall).toEqual([
+            // added and removed values reflect the ending values, not the values at the time of the call
+            ["before content change at", 0, "to add", [10, 20, 30], "to remove", [30, 20, 10]],
+            ["content change at", 0, "added", [10, 20, 30], "removed", [30, 20, 10]],
+        ]);
+    });
+
+    it("deletes one value", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 20, 30]);
+        expect(collection.delete(40)).toBe(false); // to exercise deletion of non-existing entry
+        expect(collection.delete(20)).toBe(true);
+        expect(collection.slice()).toEqual([10, 30]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 1, "to add", [], "to remove", [20]],
+            ["length change from", 3],
+            ["length change to", 2],
+            ["content change at", 1, "added", [], "removed", [20]],
+        ]);
+    });
+
+    it("clears all values finally", function () {
+        spy = jasmine.createSpy();
+        expect(collection.slice()).toEqual([10, 30]);
+        collection.clear();
+        expect(collection.slice()).toEqual([]);
+        expect(spy.argsForCall).toEqual([
+            ["before content change at", 0, "to add", [], "to remove", [10, 30]],
+            ["length change from", 2],
+            ["length change to", 0],
+            ["content change at", 0, "added", [], "removed", [10, 30]],
+        ]);
+    });
+
+    it("removes content change listeners", function () {
+        spy = jasmine.createSpy();
+
+        // mute all listeners
+
+        var descriptor = collection.getOwnPropertyChangeDescriptor('length');
+        descriptor.willChangeListeners.forEach(function (listener) {
+            collection.removeBeforeOwnPropertyChangeListener('length', listener);
+        });
+        descriptor.changeListeners.forEach(function (listener) {
+            collection.removeOwnPropertyChangeListener('length', listener);
+        });
+
+        var descriptor = collection.getRangeChangeDescriptor();
+        descriptor.willChangeListeners.forEach(function (listener) {
+            collection.removeBeforeRangeChangeListener(listener);
+        });
+        descriptor.changeListeners.forEach(function (listener) {
+            collection.removeRangeChangeListener(listener);
+        });
+
+        // modify
+        collection.splice(0, 0, 1, 2, 3);
+
+        // note silence
+        expect(spy).wasNotCalled();
+    });
+
+    // --------------- FIN -----------------
+
+    it("handles cyclic content change listeners", function () {
+        var foo = Collection([]);
+        var bar = Collection([]);
+        foo.addRangeChangeListener(function (plus, minus, index) {
+            // if this is a change in response to a change in bar,
+            // do not send back
+            if (bar.getRangeChangeDescriptor().isActive)
+                return;
+            bar.splice.apply(bar, [index, minus.length].concat(plus));
+        });
+        bar.addRangeChangeListener(function (plus, minus, index) {
+            if (foo.getRangeChangeDescriptor().isActive)
+                return;
+            foo.splice.apply(foo, [index, minus.length].concat(plus));
+        });
+        foo.push(10, 20, 30);
+        expect(bar.slice()).toEqual([10, 20, 30]);
+        bar.pop();
+        expect(foo.slice()).toEqual([10, 20]);
+    });
+
+    it("observes length changes on collections that are not otherwised observed", function () {
+        var collection = new Collection([1, 2, 3]);
+        var spy = jasmine.createSpy();
+        collection.addOwnPropertyChangeListener("length", spy);
+        collection.push(4);
+        expect(spy).toHaveBeenCalled();
+    });
+
+}
+

--- a/spec/set-spec.js
+++ b/spec/set-spec.js
@@ -36,5 +36,68 @@ describe("Set", function () {
         expect(spy).toHaveBeenCalledWith([], [1, 2, 3], 0, set, undefined);
     });
 
+    it("should dispatch range change on add", function () {
+        var set = Set([1, 3]);
+        var spy = jasmine.createSpy();
+        set.addRangeChangeListener(spy);
+        set.add(2);
+        expect(set.toArray()).toEqual([1, 3, 2]);
+        expect(spy).toHaveBeenCalledWith([2], [], 2, set, undefined);
+    });
+
+    it("should dispatch range change on delete", function () {
+        var set = Set([1, 2, 3]);
+        var spy = jasmine.createSpy();
+        set.addRangeChangeListener(spy);
+        set["delete"](2);
+        expect(set.toArray()).toEqual([1, 3]);
+        expect(spy).toHaveBeenCalledWith([], [2], 1, set, undefined);
+    });
+
+    it("should dispatch range change on pop", function () {
+        var set = Set([1, 3, 2]);
+        var spy = jasmine.createSpy();
+        set.addRangeChangeListener(spy);
+        expect(set.pop()).toEqual(2);
+        expect(set.toArray()).toEqual([1, 3]);
+        expect(spy).toHaveBeenCalledWith([], [2], 2, set, undefined);
+    });
+
+    it("should dispatch range change on shift", function () {
+        var set = Set([1, 3, 2]);
+        var spy = jasmine.createSpy();
+        set.addRangeChangeListener(spy);
+        expect(set.shift()).toEqual(1);
+        expect(set.toArray()).toEqual([3, 2]);
+        expect(spy).toHaveBeenCalledWith([], [1], 0, set, undefined);
+    });
+
+    it("should dispatch range change on shift then pop", function () {
+        var set = Set([1, 3]);
+        set.addRangeChangeListener(function (plus, minus, index) {
+            spy(plus, minus, index); // ignore all others
+        });
+
+        var spy = jasmine.createSpy();
+        expect(set.add(2)).toEqual(true);
+        expect(set.toArray()).toEqual([1, 3, 2]);
+        expect(spy).toHaveBeenCalledWith([2], [], 2);
+
+        var spy = jasmine.createSpy();
+        expect(set.shift()).toEqual(1);
+        expect(set.toArray()).toEqual([3, 2]);
+        expect(spy).toHaveBeenCalledWith([], [1], 0);
+
+        var spy = jasmine.createSpy();
+        expect(set.pop()).toEqual(2);
+        expect(set.toArray()).toEqual([3]);
+        expect(spy).toHaveBeenCalledWith([], [2], 1);
+
+        var spy = jasmine.createSpy();
+        expect(set.delete(3)).toEqual(true);
+        expect(set.toArray()).toEqual([]);
+        expect(spy).toHaveBeenCalledWith([], [3], 0);
+    });
+
 });
 


### PR DESCRIPTION
Adding a range change listener degrades the performance of List and Set
to O(n), but does allow these data structures to be bound.

This impacted range changes on Array slightly, producing a need to
improve reverse and sort range change dispatch to reflect the correct
order in plus and minus.

This also introduces an inconsistency between the way List and Array
dispatch range changes, particularly that the length is changed between
the content changes instead of wrapped around content changes.  This
should be addressed in future work.
