### PR TITLE
Hack around MontageJS serialization

### DIFF
--- a/dict.js
+++ b/dict.js
@@ -19,6 +19,8 @@ function Dict(values, getDefault) {
     this.addEach(values);
 }
 
+Dict.Dict = Dict; // hack so require("dict").Dict will work in MontageJS.
+
 function mangle(key) {
     return "~" + key;
 }

--- a/fast-map.js
+++ b/fast-map.js
@@ -31,6 +31,8 @@ function FastMap(values, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+FastMap.FastMap = FastMap; // hack so require("fast-map").FastMap will work in MontageJS
+
 Object.addEach(FastMap.prototype, GenericCollection.prototype);
 Object.addEach(FastMap.prototype, GenericMap.prototype);
 Object.addEach(FastMap.prototype, PropertyChanges.prototype);

--- a/fast-set.js
+++ b/fast-set.js
@@ -27,6 +27,8 @@ function FastSet(values, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+FastSet.FastSet = FastSet; // hack so require("fast-set").FastSet will work in MontageJS
+
 Object.addEach(FastSet.prototype, GenericCollection.prototype);
 Object.addEach(FastSet.prototype, GenericSet.prototype);
 Object.addEach(FastSet.prototype, PropertyChanges.prototype);

--- a/heap.js
+++ b/heap.js
@@ -24,6 +24,8 @@ function Heap(values, equals, compare) {
     this.addEach(values);
 }
 
+Heap.Heap = Heap; // hack so require("heap").Heap will work in MontageJS
+
 Object.addEach(Heap.prototype, GenericCollection.prototype);
 Object.addEach(Heap.prototype, PropertyChanges.prototype);
 Object.addEach(Heap.prototype, RangeChanges.prototype);

--- a/list.js
+++ b/list.js
@@ -21,6 +21,8 @@ function List(values, equals, getDefault) {
     this.addEach(values);
 }
 
+List.List = List; // hack so require("list").List will work in MontageJS
+
 Object.addEach(List.prototype, GenericCollection.prototype);
 Object.addEach(List.prototype, GenericOrder.prototype);
 Object.addEach(List.prototype, PropertyChanges.prototype);

--- a/lru-map.js
+++ b/lru-map.js
@@ -32,6 +32,8 @@ function LruMap(values, maxLength, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+LruMap.LruMap = LruMap; // hack so require("lru-map").LruMap will work in MontageJS
+
 Object.addEach(LruMap.prototype, GenericCollection.prototype);
 Object.addEach(LruMap.prototype, GenericMap.prototype);
 Object.addEach(LruMap.prototype, PropertyChanges.prototype);

--- a/lru-set.js
+++ b/lru-set.js
@@ -26,6 +26,8 @@ function LruSet(values, maxLength, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+LruSet.LruSet = LruSet; // hack so require("lru-set").LruSet will work in MontageJS
+
 Object.addEach(LruSet.prototype, GenericCollection.prototype);
 Object.addEach(LruSet.prototype, GenericSet.prototype);
 Object.addEach(LruSet.prototype, PropertyChanges.prototype);

--- a/map.js
+++ b/map.js
@@ -31,6 +31,8 @@ function Map(values, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+Map.Map = Map; // hack so require("map").Map will work in MontageJS
+
 Object.addEach(Map.prototype, GenericCollection.prototype);
 Object.addEach(Map.prototype, GenericMap.prototype); // overrides GenericCollection
 Object.addEach(Map.prototype, PropertyChanges.prototype);

--- a/multi-map.js
+++ b/multi-map.js
@@ -15,6 +15,8 @@ function MultiMap(values, bucket, equals, hash) {
     });
 }
 
+MultiMap.MultiMap = MultiMap; // hack so require("multi-map").MultiMap will work in MontageJS
+
 MultiMap.prototype = Object.create(Map.prototype);
 
 MultiMap.prototype.constructor = MultiMap;

--- a/set.js
+++ b/set.js
@@ -38,6 +38,8 @@ function Set(values, equals, hash, getDefault) {
     this.addEach(values);
 }
 
+Set.Set = Set; // hack so require("set").Set will work in MontageJS
+
 Object.addEach(Set.prototype, GenericCollection.prototype);
 Object.addEach(Set.prototype, GenericSet.prototype);
 Object.addEach(Set.prototype, PropertyChanges.prototype);

--- a/sorted-array-map.js
+++ b/sorted-array-map.js
@@ -31,6 +31,9 @@ function SortedArrayMap(values, equals, compare, getDefault) {
     this.addEach(values);
 }
 
+// hack so require("sorted-array-map").SortedArrayMap will work in MontageJS
+SortedArrayMap.SortedArrayMap = SortedArrayMap;
+
 Object.addEach(SortedArrayMap.prototype, GenericCollection.prototype);
 Object.addEach(SortedArrayMap.prototype, GenericMap.prototype);
 Object.addEach(SortedArrayMap.prototype, PropertyChanges.prototype);

--- a/sorted-array-set.js
+++ b/sorted-array-set.js
@@ -14,6 +14,9 @@ function SortedArraySet(values, equals, compare, getDefault) {
     SortedArray.call(this, values, equals, compare, getDefault);
 }
 
+// hack so require("sorted-array-set".SortedArraySet works in MontageJS
+SortedArraySet.SortedArraySet = SortedArraySet;
+
 SortedArraySet.prototype = Object.create(SortedArray.prototype);
 
 SortedArraySet.prototype.constructor = SortedArraySet;

--- a/sorted-array.js
+++ b/sorted-array.js
@@ -25,6 +25,9 @@ function SortedArray(values, equals, compare, getDefault) {
     this.addEach(values);
 }
 
+// hack so require("sorted-array").SortedArray will work in MontageJS
+SortedArray.SortedArray = SortedArray;
+
 Object.addEach(SortedArray.prototype, GenericCollection.prototype);
 Object.addEach(SortedArray.prototype, PropertyChanges.prototype);
 Object.addEach(SortedArray.prototype, RangeChanges.prototype);

--- a/sorted-map.js
+++ b/sorted-map.js
@@ -31,6 +31,9 @@ function SortedMap(values, equals, compare, getDefault) {
     this.addEach(values);
 }
 
+// hack so require("sorted-map").SortedMap will work in MontageJS
+SortedMap.SortedMap = SortedMap;
+
 Object.addEach(SortedMap.prototype, GenericCollection.prototype);
 Object.addEach(SortedMap.prototype, GenericMap.prototype);
 Object.addEach(SortedMap.prototype, PropertyChanges.prototype);

--- a/sorted-set.js
+++ b/sorted-set.js
@@ -21,6 +21,9 @@ function SortedSet(values, equals, compare, getDefault) {
     this.addEach(values);
 }
 
+// hack so require("sorted-set").SortedSet will work in MontageJS
+SortedSet.SortedSet = SortedSet;
+
 Object.addEach(SortedSet.prototype, GenericCollection.prototype);
 Object.addEach(SortedSet.prototype, GenericSet.prototype);
 Object.addEach(SortedSet.prototype, PropertyChanges.prototype);


### PR DESCRIPTION
This adds an eponymous property to the constructors of all collections
that might be used in MontageJS serializations.  MontageJS presupposes
that all modules will export an object with a property with the same
name as the module.
