### PR TITLE
Fix bug where property change listeners are not called if earlier ones removed themselves.

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -165,7 +165,7 @@ PropertyChanges.prototype.dispatchOwnPropertyChange = function (key, value, befo
 
     try {
         // dispatch to each listener
-        listeners.forEach(function (listener) {
+        listeners.slice().forEach(function (listener) {
             var thisp = listener;
             listener = (
                 listener[specificHandlerName] ||

--- a/spec/listen/property-changes-spec.js
+++ b/spec/listen/property-changes-spec.js
@@ -150,5 +150,23 @@ describe("PropertyChanges", function () {
         expect(object.handleFooChange).toHaveBeenCalled();
     });
 
+    it("calls later handlers if earlier ones remove themselves", function () {
+        var object = {
+            foo: true
+        };
+        var listener1 = {
+            handleFooChange: function (value, key, object) {
+                PropertyChanges.removeOwnPropertyChangeListener(object, key, listener1);
+            }
+        };
+        var listener2 = jasmine.createSpyObj("listener2", ["handleFooChange"]);
+
+        PropertyChanges.addOwnPropertyChangeListener(object, "foo", listener1);
+        PropertyChanges.addOwnPropertyChangeListener(object, "foo", listener2);
+
+        object.foo = false;
+        expect(listener2.handleFooChange).toHaveBeenCalled();
+    });
+
 });
 


### PR DESCRIPTION
Reported by @fabrobinet at MON-413
