### PR TITLE
Accommodate large arrays in Array's swap method.

### DIFF
--- a/spec/array-spec.js
+++ b/spec/array-spec.js
@@ -220,5 +220,37 @@ describe("Array", function () {
         });
     });
 
+    describe("swap", function () {
+        var array, otherArray;
+        beforeEach(function () {
+            array = [1, 2, 3];
+        });
+        it("should be able to replace content with content of another arraylike", function () {
+            otherArray = { __proto__ : Array.prototype };
+            otherArray[0] = 4;
+            otherArray[1] = 5;
+            otherArray.length = 2;
+            array.swap(0, array.length, otherArray);
+            expect(array).toEqual([4, 5]);
+        });
+        it("should ignore non array like plus value", function () {
+            array.swap(0, array.length, 4);
+            expect(array).toEqual([]);
+
+        });
+        it("should ignore extra arguments", function () {
+            array.swap(0, array.length, 4, 5, 6);
+            expect(array).toEqual([]);
+
+        });
+        it("should work with large arrays", function () {
+            otherArray = new Array(200000);
+            expect(function () {
+                array.swap(0, array.length, otherArray);
+            }).not.toThrow();
+            expect(array.length).toEqual(200000);
+        });
+   });
+
 });
 

--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -418,5 +418,20 @@ describe("Array change dispatch", function () {
 
     });
 
+    describe("swap", function () {
+        var otherArray;
+        beforeEach(function () {
+            array.makeObservable();
+        });
+        it("should work with large arrays", function () {
+            otherArray = new Array(200000);
+            //Should not throw a Maximum call stack size exceeded error.
+            expect(function () {
+                array.swap(0, array.length, otherArray);
+            }).not.toThrow();
+            expect(array.length).toEqual(200000);
+        });
+    });
+
 });
 


### PR DESCRIPTION
Swap now batches the underlying splice operations if necessary.
To reduce the pressure on the stack the observable splice is now based 
on swap. This will avoid doubling the stack used by nesting apply calls.
