### PR TITLE
Fix removal during dispatch

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -166,6 +166,9 @@ PropertyChanges.prototype.dispatchOwnPropertyChange = function (key, value, befo
     try {
         // dispatch to each listener
         listeners.slice().forEach(function (listener) {
+            if (listeners.indexOf(listener) < 0) {
+                return;
+            }
             var thisp = listener;
             listener = (
                 listener[specificHandlerName] ||

--- a/listen/range-changes.js
+++ b/listen/range-changes.js
@@ -110,7 +110,10 @@ RangeChanges.prototype.dispatchRangeChange = function (plus, minus, index, befor
 
         // dispatch each listener
         try {
-            listeners.forEach(function (listener) {
+            listeners.slice().forEach(function (listener) {
+                if (listeners.indexOf(listener) < 0) {
+                    return;
+                }
                 if (listener[tokenName]) {
                     listener[tokenName](plus, minus, index, this, beforeChange);
                 } else if (listener.call) {


### PR DESCRIPTION
This fixes the case where a change listener is removed during dispatch.
All listeners that existed at the beginning of change dispatch except
those that have been since removed are notified, but any listeners added
after the dispatch began are ignored.

Alternative to #46
