### PR TITLE
Leave the thunks alone

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -132,10 +132,6 @@ PropertyChanges.prototype.removeOwnPropertyChangeListener = function (key, liste
         throw new Error("Can't remove property change listener: does not exist: property name" + JSON.stringify(key));
     }
     listeners.splice(index, 1);
-
-    if (descriptor.changeListeners.length + descriptor.willChangeListeners.length === 0) {
-        PropertyChanges.makePropertyUnobservable(this, key);
-    }
 };
 
 PropertyChanges.prototype.removeBeforeOwnPropertyChangeListener = function (key, listener) {


### PR DESCRIPTION
Once an object has a property change get/set thunk, even if no one is
watching, leave it alone. Chances dictate that it will be needed again,
or the object will never be needed again. Either way, removing the thunk
is a waste of time.
