### PR TITLE
Guard against accidental arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,8 +323,11 @@ Dict)
 #### has(value, opt_equals)
 
 Whether a value exists in this collection.  This is slow for list
-(linear), but fast (logarithmic) for SortedSet and SortedArraySet,
-and very fast (constant) for Set.
+(linear), but fast (logarithmic) for SortedSet and SortedArraySet, and
+very fast (constant) for Set. However, SortedSet, SortedArray, and
+SortedArraySet have an inherent `contentEquals` function and do not
+support override, and as such will throw an exception if provided the
+`equals` argument.
 
 (Array+, List, Set, SortedSet, LruSet, SortedArray, SortedArraySet,
 FastSet)
@@ -338,9 +341,12 @@ The value for a key.  If a Map or SortedMap lacks a key, returns
 
 (Array+, Map, SortedMap, SortedArrayMap, WeakMap, Object+)
 
-#### get(value)
+#### get(value, opt_equals)
 
 Gets the equivalent value, or falls back to `getDefault(value)`.
+Sorted collections and sets have an interinsic `contentEquals`, so
+they do not accept an `equals` override and will throw an error if
+provided one.
 
 (List, Set, SortedSet, LruSet, SortedArray, SortedArraySet, FastSet)
 
@@ -398,19 +404,24 @@ Dict)
 
 #### delete(value)
 
-Deletes a value.  Returns whether the value was found.
+Deletes a value. Returns whether the value was found. Throws an error
+if a second argument, `equals`, is provided because these collections
+have an intrinsic order and `contentEquals` function.
 
 (Set, SortedSet, LruSet, SortedArray, SortedArraySet, FastSet, Heap)
 
-#### delete(value, equals)
+#### delete(value, opt_equals)
 
 Deletes the equivalent value.  Returns whether the value was found.
 
 (Array+, List)
 
-### deleteEach(values or keys)
+### deleteEach(values or keys, opt_equals)
 
-Deletes every value or every value for each key.
+Deletes every value or every value for each key. If provided an
+`equals` argument, it will be forwarded to the underlying `delete`
+implementation, which may or may not be appropriate depending on the
+collection.
 
 (Array+, List, Set, Map, MultiMap, SortedSet, SortedMap,
 LruSet, LruMap, SortedArray, SortedArraySet, SortedArrayMap,
@@ -435,18 +446,24 @@ not found.  Returns the position of the last of equivalent values.
 
 (Array, ~~List~~, SortedArray, SortedArraySet)
 
-### find(value, opt_equals)
+### find(value, opt_equals, opt_startIndex)
 
-Finds a value.  For List and SortedSet, returns the node at which
-the value was found.  For SortedSet, the optional `equals` argument
-is ignored.
+Finds a value.  For List and SortedSet, returns the node at which the
+value was found. SortedSet, SortedArray, and SortedArraySet do  not
+support overriding their inherent `equals` or `startIndex` and will
+throw an exception if provided either. A meaningful implementation
+using `startIndex` or `startNode` could possibly be implemented in a
+future release.
 
-(Array+, List, SortedSet)
+(Array+, List, SortedSet, SortedArray, SortedArraySet)
 
-### findLast(value, opt_equals)
+### findLast(value, opt_equals, opt_endIndex)
 
-Finds the last equivalent value, returning the node at which the
-value was found.
+Finds the last equivalent value, returning the node at which the value
+was found. SortedArrayn and SortedArraySet do not support overriding
+its inherent `equals` or `startIndex` and will throw an exception if
+provided either. A meaningful implementation using `startIndex` or
+`startNode` could possibly be implemented in a future release.
 
 (Array+, List, SortedArray, SortedArraySet)
 

--- a/fast-set.js
+++ b/fast-set.js
@@ -50,7 +50,10 @@ FastSet.prototype.has = function (value) {
     return this.buckets.get(hash).has(value);
 };
 
-FastSet.prototype.get = function (value) {
+FastSet.prototype.get = function (value, equals) {
+    if (equals) {
+        throw new Error("FastSet#get does not support second argument: equals");
+    }
     var hash = this.contentHash(value);
     var buckets = this.buckets;
     if (buckets.has(hash)) {
@@ -60,7 +63,10 @@ FastSet.prototype.get = function (value) {
     }
 };
 
-FastSet.prototype['delete'] = function (value) {
+FastSet.prototype["delete"] = function (value, equals) {
+    if (equals) {
+        throw new Error("FastSet#delete does not support second argument: equals");
+    }
     var hash = this.contentHash(value);
     var buckets = this.buckets;
     if (buckets.has(hash)) {

--- a/heap.js
+++ b/heap.js
@@ -81,7 +81,10 @@ Heap.prototype.indexOf = function (value) {
     return -1;
 };
 
-Heap.prototype.delete = function (value) {
+Heap.prototype["delete"] = function (value, equals) {
+    if (equals) {
+        throw new Error("Heap#delete does not support second argument: equals");
+    }
     var index = this.indexOf(value);
     if (index === -1)
         return false;

--- a/list.js
+++ b/list.js
@@ -32,10 +32,10 @@ List.prototype.constructClone = function (values) {
     return new this.constructor(values, this.contentEquals, this.getDefault);
 };
 
-List.prototype.find = function (value, equals) {
+List.prototype.find = function (value, equals, index) {
     equals = equals || this.contentEquals;
     var head = this.head;
-    var at = head.next;
+    var at = this.scan(index, head.next);
     while (at !== head) {
         if (equals(at.value, value)) {
             return at;
@@ -44,10 +44,10 @@ List.prototype.find = function (value, equals) {
     }
 };
 
-List.prototype.findLast = function (value, equals) {
+List.prototype.findLast = function (value, equals, index) {
     equals = equals || this.contentEquals;
     var head = this.head;
-    var at = head.prev;
+    var at = this.scan(index, head.prev);
     while (at !== head) {
         if (equals(at.value, value)) {
             return at;

--- a/lru-set.js
+++ b/lru-set.js
@@ -47,7 +47,10 @@ LruSet.prototype.has = function (value) {
     return this.store.has(value);
 };
 
-LruSet.prototype.get = function (value) {
+LruSet.prototype.get = function (value, equals) {
+    if (equals) {
+        throw new Error("LruSet#get does not support second argument: equals");
+    }
     value = this.store.get(value);
     if (value !== undefined) {
         this.store["delete"](value);
@@ -92,7 +95,10 @@ LruSet.prototype.add = function (value) {
     return plus.length !== minus.length;
 };
 
-LruSet.prototype["delete"] = function (value) {
+LruSet.prototype["delete"] = function (value, equals) {
+    if (equals) {
+        throw new Error("LruSet#delete does not support second argument: equals");
+    }
     var found = this.store.has(value);
     if (found) {
         if (this.dispatchesRangeChanges) {

--- a/set.js
+++ b/set.js
@@ -57,7 +57,10 @@ Set.prototype.has = function (value) {
     return this.store.has(node);
 };
 
-Set.prototype.get = function (value) {
+Set.prototype.get = function (value, equals) {
+    if (equals) {
+        throw new Error("Set#get does not support second argument: equals");
+    }
     var node = new this.order.Node(value);
     node = this.store.get(node);
     if (node) {
@@ -86,7 +89,10 @@ Set.prototype.add = function (value) {
     return false;
 };
 
-Set.prototype["delete"] = function (value) {
+Set.prototype["delete"] = function (value, equals) {
+    if (equals) {
+        throw new Error("Set#delete does not support second argument: equals");
+    }
     var node = new this.order.Node(value);
     if (this.store.has(node)) {
         var node = this.store.get(node);

--- a/sorted-array.js
+++ b/sorted-array.js
@@ -103,12 +103,18 @@ SortedArray.prototype.constructClone = function (values) {
     );
 };
 
-SortedArray.prototype.has = function (value) {
+SortedArray.prototype.has = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedSet#has does not support second argument: equals");
+    }
     var index = search(this.array, value, this.contentCompare);
     return index >= 0 && this.contentEquals(this.array[index], value);
 };
 
-SortedArray.prototype.get = function (value) {
+SortedArray.prototype.get = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedArray#get does not support second argument: equals");
+    }
     var index = searchFirst(this.array, value, this.contentCompare, this.contentEquals);
     if (index !== -1) {
         return this.array[index];
@@ -130,7 +136,10 @@ SortedArray.prototype.add = function (value) {
     return true;
 };
 
-SortedArray.prototype["delete"] = function (value) {
+SortedArray.prototype["delete"] = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedArray#delete does not support second argument: equals");
+    }
     var index = searchFirst(this.array, value, this.contentCompare, this.contentEquals);
     if (index !== -1) {
         if (this.dispatchesRangeChanges) {
@@ -155,11 +164,23 @@ SortedArray.prototype.lastIndexOf = function (value) {
     return searchLast(this.array, value, this.contentCompare, this.contentEquals);
 };
 
-SortedArray.prototype.find = function (value) {
+SortedArray.prototype.find = function (value, equals, index) {
+    if (equals) {
+        throw new Error("SortedArray#find does not support second argument: equals");
+    }
+    if (index) {
+        throw new Error("SortedArray#find does not support third argument: index");
+    }
     return searchFirst(this.array, value, this.contentCompare, this.contentEquals);
 };
 
-SortedArray.prototype.findLast = function (value) {
+SortedArray.prototype.findLast = function (value, equals, index) {
+    if (equals) {
+        throw new Error("SortedArray#findLast does not support second argument: equals");
+    }
+    if (index) {
+        throw new Error("SortedArray#findLast does not support third argument: index");
+    }
     return searchLast(this.array, value, this.contentCompare, this.contentEquals);
 };
 

--- a/sorted-set.js
+++ b/sorted-set.js
@@ -38,7 +38,10 @@ SortedSet.prototype.constructClone = function (values) {
     );
 };
 
-SortedSet.prototype.has = function (value) {
+SortedSet.prototype.has = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedSet#has does not support second argument: equals");
+    }
     if (this.root) {
         this.splay(value);
         return this.contentEquals(value, this.root.value);
@@ -47,7 +50,10 @@ SortedSet.prototype.has = function (value) {
     }
 };
 
-SortedSet.prototype.get = function (value) {
+SortedSet.prototype.get = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedSet#get does not support second argument: equals");
+    }
     if (this.root) {
         this.splay(value);
         if (this.contentEquals(value, this.root.value)) {
@@ -116,7 +122,10 @@ SortedSet.prototype.add = function (value) {
     return false;
 };
 
-SortedSet.prototype['delete'] = function (value) {
+SortedSet.prototype['delete'] = function (value, equals) {
+    if (equals) {
+        throw new Error("SortedSet#delete does not support second argument: equals");
+    }
     if (this.root) {
         this.splay(value);
         if (this.contentEquals(value, this.root.value)) {
@@ -150,7 +159,10 @@ SortedSet.prototype['delete'] = function (value) {
     return false;
 };
 
-SortedSet.prototype.indexOf = function (value) {
+SortedSet.prototype.indexOf = function (value, index) {
+    if (index) {
+        throw new Error("SortedSet#indexOf does not support second argument: startIndex");
+    }
     if (this.root) {
         this.splay(value);
         if (this.contentEquals(value, this.root.value)) {
@@ -160,7 +172,15 @@ SortedSet.prototype.indexOf = function (value) {
     return -1;
 };
 
-SortedSet.prototype.find = function (value) {
+SortedSet.prototype.find = function (value, equals, index) {
+    if (equals) {
+        throw new Error("SortedSet#find does not support second argument: equals");
+    }
+    if (index) {
+        // TODO contemplate using splayIndex to isolate a subtree in
+        // which to search.
+        throw new Error("SortedSet#find does not support third argument: index");
+    }
     if (this.root) {
         this.splay(value);
         if (this.contentEquals(value, this.root.value)) {


### PR DESCRIPTION
Some interfaces allow or disallow overriding `equals` or `index`
arguments depending on the intrinsic qualities of the collection. Per
recommendation from @daira, this commit alters those collections that
forbid these arguments such that they throw an error.

Documentation updated as well.
