### PR TITLE
Correctly report the plus on out of range splices

### DIFF
--- a/listen/array-changes.js
+++ b/listen/array-changes.js
@@ -122,6 +122,13 @@ var observableArrayProperties = {
                 if (!Array.isArray(plus)) {
                     plus = array_slice.call(plus);
                 }
+                if (start > this.length) {
+                    // pad trailing undefined created implicitly by splice
+                    var paddingSize = start - this.length;
+                    plus.unshift.apply(plus, new Array(paddingSize));
+                    length += paddingSize;
+                    start = this.length;
+                }
             } else {
                 plus = EMPTY_ARRAY;
             }

--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -224,6 +224,28 @@ describe("Array change dispatch", function () {
 
     // ---- fresh start
 
+    it("splices two values outside the array range", function () {
+        array.clear();
+        array.push(10, 20, 30);
+
+        spy = jasmine.createSpy();
+        expect(array).toEqual([10, 20, 30]);
+        expect(array.splice(4, 0, 50)).toEqual([]);
+        expect(array).toEqual([10, 20, 30, undefined, 50]);
+        expect(spy.argsForCall).toEqual([
+            ["length change from", 3],
+            ["before content change at", 3, "to add", [undefined, 50], "to remove", []],
+            ["change at", 3, "from", undefined],
+            ["change at", 4, "from", undefined],
+            ["change at", 3, "to", undefined],
+            ["change at", 4, "to", 50],
+            ["content change at", 3, "added", [undefined, 50], "removed", []],
+            ["length change to", 5]
+        ]);
+    });
+
+    // ---- fresh start
+
     it("unshifts one to the beginning", function () {
         array.clear(); // start over fresh
         expect(array).toEqual([]);


### PR DESCRIPTION
When splice is given an out of range index it implicitly adds new
undefined values to the array.
The observers were not contemplating this situation and the plus only had
the values given explicitly to the splice/swap operation.
