### PR TITLE
Cap splice's index parameter to length

### DIFF
--- a/listen/array-changes.js
+++ b/listen/array-changes.js
@@ -199,6 +199,11 @@ var observableArrayProperties = {
 
     splice: {
         value: function splice(start, length) {
+            // start parameter should be min(start, this.length)
+            // http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.12
+            if (start > this.length) {
+                start = this.length;
+            }
             return this.swap.call(this, start, length, array_slice.call(arguments, 2));
         },
         writable: true,

--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -222,6 +222,24 @@ describe("Array change dispatch", function () {
         ]);
     });
 
+    it("splices two values outside the array range", function () {
+        array.clear();
+        array.push(10, 20, 30);
+
+        spy = jasmine.createSpy();
+        expect(array).toEqual([10, 20, 30]);
+        expect(array.splice(4, 0, 50)).toEqual([]);
+        expect(array).toEqual([10, 20, 30, 50]);
+        expect(spy.argsForCall).toEqual([
+            ["length change from", 3],
+            ["before content change at", 3, "to add", [50], "to remove", []],
+            ["change at", 3, "from", undefined],
+            ["change at", 3, "to", 50],
+            ["content change at", 3, "added", [50], "removed", []],
+            ["length change to", 4]
+       ]);
+    });
+
     // ---- fresh start
 
     it("unshifts one to the beginning", function () {


### PR DESCRIPTION
When the index parameter of a splice is beyond its length then the
length should be taken as the index.

http://www.ecma-international.org/ecma-262/5.1/#sec-15.4.4.12

```
6. If relativeStart is negative, let actualStart be max((len + relativeStart),0); else let actualStart be min(relativeStart, len).
```
