### PR TITLE
Backport improvments to equals and compare

### DIFF
--- a/spec/shim-object-spec.js
+++ b/spec/shim-object-spec.js
@@ -315,7 +315,7 @@ describe("Object", function () {
                 return this;
             },
             equals: function (n) {
-                return n === 10 || typeof n === "object" && n.value === 10;
+                return n === 10 || typeof n === "object" && n !== null && n.value === 10;
             }
         };
 
@@ -422,7 +422,7 @@ describe("Object", function () {
             [[10], [10], 0],
             [[10], [20], -10],
             [[100, 10], [100, 0], 10],
-            ["a", "b", -1],
+            ["a", "b", -Infinity],
             [now, now, 0, "now to itself"],
             [
                 comparable.create(function () {


### PR DESCRIPTION
Using -Infinity and +Infinity instead of arbitrary -1 or 1 for string
comparison prevents "viscinity checks", like, is this string _near_ this
other one, from getting confused.

Much less cleverness about comparing null and undefined so that
polymorphic comparators get a chance to run if they exist.

Fixes for a bug in equals for same-shaped cyclic structures. Upon
encountering a memo entry, return true and rely on the parent call to
return false if the values are in fact inequal.

Avoid redundant equals calls in comparing object literals. Only compare
object literals, not objects derriving from the same prototype.
