### PR TITLE
Fix set and swap at outer index issues

### DIFF
--- a/listen/array-changes.js
+++ b/listen/array-changes.js
@@ -128,7 +128,18 @@ var observableArrayProperties = {
 
             if (start < 0) {
                 start = this.length + start;
+            } else if (start > this.length) {
+                var holes = start - this.length;
+                var newPlus = Array(holes + plus.length);
+                for (var i = 0, j = holes; i < plus.length; i++, j++) {
+                    if (i in plus) {
+                        newPlus[j] = plus[i];
+                    }
+                }
+                plus = newPlus;
+                start = this.length;
             }
+
             var minus;
             if (length === 0) {
                 // minus will be empty
@@ -216,8 +227,8 @@ var observableArrayProperties = {
 
     set: {
         value: function set(index, value) {
-            this.splice(index, 1, value);
-            return this;
+            this.swap(index, index >= this.length ? 0 : 1, [value]);
+            return true;
         },
         writable: true,
         configurable: true

--- a/shim-array.js
+++ b/shim-array.js
@@ -100,7 +100,7 @@ define("get", function (index, defaultValue) {
 });
 
 define("set", function (index, value) {
-    this.splice(index, 1, value);
+    this[index] = value;
     return true;
 });
 
@@ -142,6 +142,9 @@ define("findLast", function (value, equals) {
 
 define("swap", function (start, length, plus) {
     var args, plusLength, i, j, returnValue;
+    if (start > this.length) {
+        this.length = start;
+    }
     if (typeof plus !== "undefined") {
         args = [start, length];
         if (!Array.isArray(plus)) {

--- a/spec/array-spec.js
+++ b/spec/array-spec.js
@@ -250,6 +250,40 @@ describe("Array", function () {
             }).not.toThrow();
             expect(array.length).toEqual(200000);
         });
+        it("swaps at an outer index", function () {
+            array.swap(4, 0, [5]);
+            expect(array).toEqual([1, 2, 3, , 5]);
+        });
+   });
+
+   describe("set", function () {
+
+       it("sets an inner index", function () {
+           var array = [1, 2, 3];
+           array.set(1, 10);
+           expect(array).toEqual([1, 10, 3]);
+       });
+
+       it("sets an inner index of an observed array", function () {
+           var array = [1, 2, 3];
+           array.makeObservable();
+           array.set(1, 10);
+           expect(array).toEqual([1, 10, 3]);
+       });
+
+       it("sets an outer index", function () {
+           var array = [];
+           array.set(4, 10);
+           expect(array).toEqual([ , , , , 10]);
+       });
+
+       it("sets an outer index of an observed array", function () {
+           var array = [];
+           array.makeObservable();
+           array.set(4, 10);
+           expect(array).toEqual([ , , , , 10]);
+       });
+
    });
 
 });

--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -197,7 +197,7 @@ describe("Array change dispatch", function () {
     it("sets new value at end", function () {
         spy = jasmine.createSpy();
         expect(array).toEqual([20, 30]);
-        expect(array.set(2, 40)).toBe(array);
+        expect(array.set(2, 40)).toBe(true);
         expect(array).toEqual([20, 30, 40]);
         expect(spy.argsForCall).toEqual([
             ["length change from", 2],
@@ -212,7 +212,7 @@ describe("Array change dispatch", function () {
     it("sets new value at beginning", function () {
         spy = jasmine.createSpy();
         expect(array).toEqual([20, 30, 40]);
-        expect(array.set(0, 10)).toBe(array);
+        expect(array.set(0, 10)).toBe(true);
         expect(array).toEqual([10, 30, 40]);
         expect(spy.argsForCall).toEqual([
             ["before content change at", 0, "to add", [10], "to remove", [20]],
@@ -329,6 +329,25 @@ describe("Array change dispatch", function () {
             ["content change at", 1, "added", [], "removed", [20]],
             ["length change to", 2]
         ]);
+    });
+
+    it("sets a value outside the existing range", function () {
+        expect(array).toEqual([10, 30]);
+        spy = jasmine.createSpy();
+        expect(array.set(3, 40)).toBe(true);
+        expect(array).toEqual([10, 30, , 40]);
+        expect(spy.argsForCall).toEqual([
+            ["length change from", 2],
+            ["before content change at", 2, "to add", [ , 40], "to remove", []],
+            ["change at", 2, "from", undefined],
+            ["change at", 3, "from", undefined],
+            ["change at", 2, "to", undefined],
+            ["change at", 3, "to", 40],
+            ["content change at", 2, "added", [ , 40], "removed", []],
+            ["length change to", 4]
+        ]);
+        array.pop();
+        array.pop();
     });
 
     it("clears all values finally", function () {


### PR DESCRIPTION
For both observed and unobserved arrays.

Splice truncates the start index to the array length. Swap and set do
not.
