### PR TITLE
Ignore property changes on non-configurables

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -247,7 +247,7 @@ PropertyChanges.prototype.makePropertyObservable = function (key) {
     };
 
     if (!overriddenDescriptor.configurable) {
-        throw new Error("Can't observe non-configurable properties");
+        return;
     }
 
     // memoize the descriptor so we know not to install another layer,


### PR DESCRIPTION
In Safari, properties of hosted objects (particularly DOM elements) are
not configurable so observing a property on a DOM element, even if to
traverse to an observable object, would fail with an error. This change
allows observers to proceed on the assumption that the non-configurable
property will not be changed.

This change fixes https://github.com/kriskowal/tengwarjs/issues/1
