### PR TITLE
Property change listener efficiency changes

### DIFF
--- a/spec/listen/array-changes-spec.js
+++ b/spec/listen/array-changes-spec.js
@@ -373,10 +373,10 @@ describe("Array change dispatch", function () {
         // mute all listeners
 
         var descriptor = array.getOwnPropertyChangeDescriptor('length');
-        descriptor.willChangeListeners.forEach(function (listener) {
+        descriptor.willChangeListeners.current.forEach(function (listener) {
             array.removeBeforeOwnPropertyChangeListener('length', listener);
         });
-        descriptor.changeListeners.forEach(function (listener) {
+        descriptor.changeListeners.current.forEach(function (listener) {
             array.removeOwnPropertyChangeListener('length', listener);
         });
 

--- a/spec/listen/property-changes-spec.js
+++ b/spec/listen/property-changes-spec.js
@@ -21,9 +21,6 @@ describe("PropertyChanges", function () {
         });
         object.x = 10;
         expect(object.x).toEqual(10);
-        PropertyChanges.makePropertyUnobservable(object, 'x');
-        object.x = 20;
-        expect(object.x).toEqual(20);
         expect(spy.argsForCall).toEqual([
             ['from', undefined, 'x'],
             ['to', 10, 'x'],

--- a/spec/listen/range-changes.js
+++ b/spec/listen/range-changes.js
@@ -246,10 +246,10 @@ function describeRangeChanges(Collection) {
         // mute all listeners
 
         var descriptor = collection.getOwnPropertyChangeDescriptor('length');
-        descriptor.willChangeListeners.forEach(function (listener) {
+        descriptor.willChangeListeners.current.forEach(function (listener) {
             collection.removeBeforeOwnPropertyChangeListener('length', listener);
         });
-        descriptor.changeListeners.forEach(function (listener) {
+        descriptor.changeListeners.current.forEach(function (listener) {
             collection.removeOwnPropertyChangeListener('length', listener);
         });
 


### PR DESCRIPTION
-   Using direct non-enumerable `__` prefixed properties instead of weak
  maps for fast access to change listener records and overridden
  property descriptors.
-   Method names and reusable active dispatch array now kept in book
  keeping to avoid recomputation.
-   Presumed hot dispatch loop factored into separate method to isolate
  from try/catch deoptimization.
-   Removed support for uninstalling property change listeners.
