### PR TITLE
Fix for a regression in Montage’s repetition where objects inside the re...

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -122,7 +122,7 @@ PropertyChanges.prototype.addOwnPropertyChangeListener = function (key, listener
 
     var self = this;
     return function cancelOwnPropertyChangeListener() {
-        PropertyChanges.removeOwnPropertyChangeListener(self, key, listener, beforeChange);
+        PropertyChanges.removeOwnPropertyChangeListener(self, key, listeners.current, beforeChange);
         self = null;
     };
 };
@@ -167,6 +167,8 @@ PropertyChanges.prototype.dispatchOwnPropertyChange = function (key, value, befo
         listeners = descriptor.changeListeners;
     }
 
+	if(listeners.lenth === 0) return;
+
     try {
         // dispatch to each listener
         dispatchEach.call(this, listeners, key, value);
@@ -187,7 +189,8 @@ function dispatchEach(listeners, key, value) {
     for (var index = 0, length = active.length; index < length; index++) {
         var listener = active[index];
         if (current.indexOf(listener) < 0) {
-            return;
+			//This is fixing the issue causing a regression in Montage's repetition
+            continue;
         }
         var thisp = listener;
         listener = (
@@ -238,7 +241,7 @@ PropertyChanges.prototype.makePropertyObservable = function (key) {
     if (!this.__overriddenPropertyDescriptors__) {
         overriddenPropertyDescriptors = {};
         Object.defineProperty(this, "__overriddenPropertyDescriptors__", {
-            value: {},
+            value: overriddenPropertyDescriptors,
             enumerable: false,
             writable: true,
             configurable: true


### PR DESCRIPTION
...petition were not being notified of changes anymore. This worked as expected in collections version 1.1.0 but has been broken since. A test has been added to montage specs to catch future regressions
