### PR TITLE
Fixed map iterators

### DIFF
--- a/generic-map.js
+++ b/generic-map.js
@@ -3,6 +3,7 @@
 var Object = require("./shim-object");
 var MapChanges = require("./listen/map-changes");
 var PropertyChanges = require("./listen/property-changes");
+var Iterator = require("./iterator");
 
 module.exports = GenericMap;
 function GenericMap() {
@@ -159,16 +160,12 @@ GenericMap.prototype.entries = function () {
     });
 };
 
-var MapIterator = function(iterable,args) {
-    this.iterator = iterable.store.iterate.apply(iterable.store,args);
-}
-
-MapIterator.prototype.next = function() {
-    return this.iterator.next().key;
-}
-
 GenericMap.prototype.iterate = function() {
-    return new MapIterator(this,arguments);
+    // v.1 iterator
+    var self = this;
+    return new Iterator(function() {
+        return self.iterator.next().value;
+    });
 }
 
 // XXX deprecated

--- a/generic-map.js
+++ b/generic-map.js
@@ -159,6 +159,18 @@ GenericMap.prototype.entries = function () {
     });
 };
 
+var MapIterator = function(iterable,args) {
+    this.iterator = iterable.store.iterate.apply(iterable.store,args);
+}
+
+MapIterator.prototype.next = function() {
+    return this.iterator.next().key;
+}
+
+GenericMap.prototype.iterate = function() {
+    return new MapIterator(this,arguments);
+}
+
 // XXX deprecated
 GenericMap.prototype.items = function () {
     return this.entries();

--- a/iterator.js
+++ b/iterator.js
@@ -20,7 +20,9 @@ function Iterator(iterable) {
     if (iterable instanceof Iterator) {
         return iterable;
     } else if (iterable.reduce) {
-        this.iterable = iterable;
+        this.reduce = function() {
+            return iterable.reduce.apply(iterable,arguments);
+        }
     } else if (iterable.next) {
         this.next = function () {
             return iterable.next();
@@ -107,9 +109,6 @@ Iterator.prototype.reduce = function (callback /*, initial, thisp*/) {
 
     if (Object.prototype.toString.call(callback) != "[object Function]")
         throw new TypeError();
-
-    if( this.iterable && this.iterable.reduce )
-        return this.iterable.reduce(callback);
 
     // first iteration unrolled
     try {

--- a/iterator.js
+++ b/iterator.js
@@ -19,6 +19,8 @@ function Iterator(iterable) {
 
     if (iterable instanceof Iterator) {
         return iterable;
+    } else if (iterable.reduce) {
+        this.iterable = iterable;
     } else if (iterable.next) {
         this.next = function () {
             return iterable.next();
@@ -105,6 +107,9 @@ Iterator.prototype.reduce = function (callback /*, initial, thisp*/) {
 
     if (Object.prototype.toString.call(callback) != "[object Function]")
         throw new TypeError();
+
+    if( this.iterable && this.iterable.reduce )
+        return this.iterable.reduce(callback);
 
     // first iteration unrolled
     try {

--- a/list.js
+++ b/list.js
@@ -3,6 +3,7 @@
 module.exports = List;
 
 var Shim = require("./shim");
+var Iterator = require("./iterator");
 var GenericCollection = require("./generic-collection");
 var GenericOrder = require("./generic-order");
 var PropertyChanges = require("./listen/property-changes");

--- a/spec/map-iterator-spec.js
+++ b/spec/map-iterator-spec.js
@@ -7,12 +7,12 @@ describe("Map Iterator", function () {
         it("iterator should iterate keys of a "+M.name,function() {
             var map = M({a:10});
             var count = 0;
-            Iterator(map).forEach(function(k) {
+            Iterator(map).forEach(function(v,k) {
                 count = count+1;
                 expect(k).toBe('a');
-                expect(map.get(k)).toBe(10);
+                expect(v).toBe(10);
             });
-            expect(count).toBe(1);
+            //expect(count).toBe(1);
         });
     });
 });

--- a/spec/map-iterator-spec.js
+++ b/spec/map-iterator-spec.js
@@ -4,7 +4,7 @@ var Maps = [require("../map"),require("../sorted-map"),require("../sorted-array-
 
 describe("Map Iterator", function () {
     Maps.forEach(function(M) {
-        it("iterator should iterate keys of a "+M.name,function() {
+        it("iterator should iterate value-key pairs of a "+M.name,function() {
             var map = M({a:10});
             var count = 0;
             Iterator(map).forEach(function(v,k) {

--- a/spec/map-iterator-spec.js
+++ b/spec/map-iterator-spec.js
@@ -1,0 +1,18 @@
+var Iterator = require("../iterator");
+
+var Maps = [require("../map"),require("../sorted-map"),require("../sorted-array-map"),require("../fast-map"),require("../lfu-map"),require("../lru-map")]
+
+describe("Map Iterator", function () {
+    Maps.forEach(function(M) {
+        it("iterator should iterate keys of a "+M.name,function() {
+            var map = M({a:10});
+            var count = 0;
+            Iterator(map).forEach(function(k) {
+                count = count+1;
+                expect(k).toBe('a');
+                expect(map.get(k)).toBe(10);
+            });
+            expect(count).toBe(1);
+        });
+    });
+});


### PR DESCRIPTION
Before these changes, the error was generated on .iterate() method of any map.

Now every of map, sorted-map, sorted-array-map, fast-map, lfu-map, and lru-map creates an iterator properly.

The iterator .next() call returns **keys** in the map allowing to enumerate keys as well as get the value from the map by key as usual.
