### PR TITLE
Using `Object.create(null)` instead of `{}`

### DIFF
--- a/dict.js
+++ b/dict.js
@@ -14,7 +14,7 @@ function Dict(values, getDefault) {
     }
     getDefault = getDefault || Function.noop;
     this.getDefault = getDefault;
-    this.store = {};
+    this.store = Object.create(null);
     this.length = 0;
     this.addEach(values);
 }


### PR DESCRIPTION
We use `for..in` or `if..in` more often in other functions, which will give us unexpected results with inherited properties from the prototype chain. So, its safer to use `Object.create(null)`