### PR TITLE
Add flag to allow active descriptors in listeners

### DIFF
--- a/listen/map-changes.js
+++ b/listen/map-changes.js
@@ -32,24 +32,26 @@ MapChanges.prototype.getAllMapChangeDescriptors = function () {
     return mapChangeDescriptors.get(this);
 };
 
-MapChanges.prototype.getMapChangeDescriptor = function (token) {
+MapChanges.prototype.getMapChangeDescriptor = function (token, allowActive) {
     var tokenChangeDescriptors = this.getAllMapChangeDescriptors();
     token = token || "";
+    allowActive = allowActive || false;
     if (!tokenChangeDescriptors.has(token)) {
         tokenChangeDescriptors.set(token, {
             willChangeListeners: new List(),
-            changeListeners: new List()
+            changeListeners: new List(),
+            allowActive: allowActive
         });
     }
     return tokenChangeDescriptors.get(token);
 };
 
-MapChanges.prototype.addMapChangeListener = function (listener, token, beforeChange) {
+MapChanges.prototype.addMapChangeListener = function (listener, token, beforeChange, allowActive) {
     if (!this.isObservable && this.makeObservable) {
         // for Array
         this.makeObservable();
     }
-    var descriptor = this.getMapChangeDescriptor(token);
+    var descriptor = this.getMapChangeDescriptor(token, allowActive);
     var listeners;
     if (beforeChange) {
         listeners = descriptor.willChangeListeners;
@@ -97,7 +99,7 @@ MapChanges.prototype.dispatchMapChange = function (key, value, beforeChange) {
     var changeName = "Map" + (beforeChange ? "WillChange" : "Change");
     descriptors.forEach(function (descriptor, token) {
 
-        if (descriptor.isActive) {
+        if (descriptor.isActive && ! descriptor.allowActive) {
             return;
         } else {
             descriptor.isActive = true;
@@ -133,7 +135,7 @@ MapChanges.prototype.dispatchMapChange = function (key, value, beforeChange) {
     }, this);
 };
 
-MapChanges.prototype.addBeforeMapChangeListener = function (listener, token) {
+MapChanges.prototype.addBeforeMapChangeListener = function (listener, token, allowActive) {
     return this.addMapChangeListener(listener, token, true);
 };
 

--- a/listen/range-changes.js
+++ b/listen/range-changes.js
@@ -17,26 +17,28 @@ RangeChanges.prototype.getAllRangeChangeDescriptors = function () {
     return rangeChangeDescriptors.get(this);
 };
 
-RangeChanges.prototype.getRangeChangeDescriptor = function (token) {
+RangeChanges.prototype.getRangeChangeDescriptor = function (token, allowActive) {
     var tokenChangeDescriptors = this.getAllRangeChangeDescriptors();
     token = token || "";
+    allowActive = allowActive || false;
     if (!tokenChangeDescriptors.has(token)) {
         tokenChangeDescriptors.set(token, {
             isActive: false,
             changeListeners: [],
-            willChangeListeners: []
+            willChangeListeners: [],
+            allowActive: allowActive
         });
     }
     return tokenChangeDescriptors.get(token);
 };
 
-RangeChanges.prototype.addRangeChangeListener = function (listener, token, beforeChange) {
+RangeChanges.prototype.addRangeChangeListener = function (listener, token, beforeChange, allowActive) {
     // a concession for objects like Array that are not inherently observable
     if (!this.isObservable && this.makeObservable) {
         this.makeObservable();
     }
 
-    var descriptor = this.getRangeChangeDescriptor(token);
+    var descriptor = this.getRangeChangeDescriptor(token, allowActive);
 
     var listeners;
     if (beforeChange) {
@@ -87,7 +89,7 @@ RangeChanges.prototype.dispatchRangeChange = function (plus, minus, index, befor
     var changeName = "Range" + (beforeChange ? "WillChange" : "Change");
     descriptors.forEach(function (descriptor, token) {
 
-        if (descriptor.isActive) {
+        if (descriptor.isActive && ! descriptor.allowActive) {
             return;
         } else {
             descriptor.isActive = true;
@@ -128,7 +130,7 @@ RangeChanges.prototype.dispatchRangeChange = function (plus, minus, index, befor
     }, this);
 };
 
-RangeChanges.prototype.addBeforeRangeChangeListener = function (listener, token) {
+RangeChanges.prototype.addBeforeRangeChangeListener = function (listener, token, allowActive) {
     return this.addRangeChangeListener(listener, token, true);
 };
 


### PR DESCRIPTION
In regards to issue #121:

There are times when listeners might want to make changes that trigger
further events in a collection.  I had a bug in my code around this
point and only realized that further collection changes are suppressed
by default.  This patch adds an override flag to allow for descriptors
to fire their listeners again even if currently active.

Signed-off-by: Fred Kilbourn <fred@fredk.com>