### PR TITLE
Pass all given arguments into a descriptor's setter, not just the value

### DIFF
--- a/listen/property-changes.js
+++ b/listen/property-changes.js
@@ -340,7 +340,7 @@ PropertyChanges.prototype.makePropertyObservable = function (key) {
                     descriptor,
                     isActive;
 
-                overriddenDescriptor.set.call(this, value);
+                overriddenDescriptor.set.apply(this, arguments);
                 value = this[key];
                 if (value !== formerValue) {
                     descriptor = this.__propertyChangeListeners__[key];


### PR DESCRIPTION
Required by matte's autocomplete component, which uses a second setter parameter to identify whether the input is from the user.