### PR TITLE
Fix Bugs/array.prototype.find in v1 master

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,4 +32,8 @@ NodeJS or open `test/run.html` in a browser.
 To run the tests in your browser, simply use `npm run test:jasmine`.
 
 To run the tests using Karma use `npm run test:karma` and for continious tests run with file changes detection `npm run test:karma-dev`. Finally to open a remote debug console on karma use `npm run test:karma-debug`.
+=======
+## Design principles
+
+- extends core types (e.g extends `Array.prototype` with additional non-enumerable properties like `.set`)
 

--- a/deque.js
+++ b/deque.js
@@ -346,8 +346,14 @@ Deque.prototype.lastIndexOf = function (value, index) {
     return -1;
 }
 
-// TODO rename findValue
-Deque.prototype.find = function (value, equals, index) {
+Deque.prototype.find = function () {
+    if (typeof console.warn === 'function') {
+        console.warn('.find function is deprecated please use findValue instead.');
+    }  
+    return Deque.prototype.findValue.apply(this, arguments);
+};
+
+Deque.prototype.findValue = function (value, equals, index) {
     equals = equals || Object.equals;
     // Default start index at beginning
     if (index == null) {
@@ -368,8 +374,14 @@ Deque.prototype.find = function (value, equals, index) {
     return -1;
 };
 
-// TODO rename findLastValue
-Deque.prototype.findLast = function (value, equals, index) {
+Deque.prototype.findLast = function () {
+    if (typeof console.warn === 'function') {
+        console.warn('.findLast function is deprecated please use findLastValue instead.');
+    }  
+    return Deque.prototype.findLastValue.apply(this, arguments);
+};
+
+Deque.prototype.findLastValue = function (value, equals, index) {
     equals = equals || Object.equals;
     // Default start position at the end
     if (index == null) {

--- a/deque.js
+++ b/deque.js
@@ -12,6 +12,19 @@ var RangeChanges = require("./listen/range-changes");
 // 1. Incrementally maintained length
 // 2. Modulus avoided by using only powers of two for the capacity
 
+var deprecatedWarnNonce = {};
+function deprecatedWarn(msg, notOnce) {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function' &&
+                (notOnce !== true && deprecatedWarnNonce.hasOwnProperty(msg) === false)
+    ) {
+        console.warn(msg);
+        deprecatedWarnNonce[msg]++;
+        debugger;
+    }
+}
+
 module.exports = Deque;
 function Deque(values, capacity) {
     if (!(this instanceof Deque)) {
@@ -347,13 +360,8 @@ Deque.prototype.lastIndexOf = function (value, index) {
 }
 
 Deque.prototype.find = function () {
-    if (
-        typeof console !== 'undefined' &&
-            typeof console.warn === 'function'
-    ) {
-        console.warn('.find function is deprecated please use findValue instead.');
-    }  
-    return Deque.prototype.findValue.apply(this, arguments);
+    deprecatedWarn('.find function is deprecated please use findValue instead.');
+    return this.findValue.apply(this, arguments);
 };
 
 Deque.prototype.findValue = function (value, equals, index) {
@@ -378,13 +386,8 @@ Deque.prototype.findValue = function (value, equals, index) {
 };
 
 Deque.prototype.findLast = function () {
-    if (
-        typeof console !== 'undefined' &&
-            typeof console.warn === 'function'
-    ) {
-        console.warn('.findLast function is deprecated please use findLastValue instead.');
-    }  
-    return Deque.prototype.findLastValue.apply(this, arguments);
+    deprecatedWarn('.findLast function is deprecated please use findLastValue instead.');
+    return this.findLastValue.apply(this, arguments);
 };
 
 Deque.prototype.findLastValue = function (value, equals, index) {

--- a/deque.js
+++ b/deque.js
@@ -347,7 +347,10 @@ Deque.prototype.lastIndexOf = function (value, index) {
 }
 
 Deque.prototype.find = function () {
-    if (typeof console.warn === 'function') {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function'
+    ) {
         console.warn('.find function is deprecated please use findValue instead.');
     }  
     return Deque.prototype.findValue.apply(this, arguments);
@@ -375,7 +378,10 @@ Deque.prototype.findValue = function (value, equals, index) {
 };
 
 Deque.prototype.findLast = function () {
-    if (typeof console.warn === 'function') {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function'
+    ) {
         console.warn('.findLast function is deprecated please use findLastValue instead.');
     }  
     return Deque.prototype.findLastValue.apply(this, arguments);

--- a/deque.js
+++ b/deque.js
@@ -12,19 +12,6 @@ var RangeChanges = require("./listen/range-changes");
 // 1. Incrementally maintained length
 // 2. Modulus avoided by using only powers of two for the capacity
 
-var deprecatedWarnNonce = {};
-function deprecatedWarn(msg, notOnce) {
-    if (
-        typeof console !== 'undefined' &&
-            typeof console.warn === 'function' &&
-                (notOnce !== true && deprecatedWarnNonce.hasOwnProperty(msg) === false)
-    ) {
-        console.warn(msg);
-        deprecatedWarnNonce[msg]++;
-        debugger;
-    }
-}
-
 module.exports = Deque;
 function Deque(values, capacity) {
     if (!(this instanceof Deque)) {
@@ -359,8 +346,21 @@ Deque.prototype.lastIndexOf = function (value, index) {
     return -1;
 }
 
+var deprecatedWarnNonce = {};
+function deprecatedWarn(msg, notOnce) {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function' &&
+                (notOnce !== true && deprecatedWarnNonce.hasOwnProperty(msg) === false)
+    ) {
+        console.warn(msg);
+        deprecatedWarnNonce[msg]++;
+    }
+}
+
+// TODO remove in v6 (not present in v2)
 Deque.prototype.find = function () {
-    deprecatedWarn('.find function is deprecated please use findValue instead.');
+    deprecatedWarn('Deque#find function is deprecated please use Deque#findValue instead.');
     return this.findValue.apply(this, arguments);
 };
 
@@ -385,8 +385,9 @@ Deque.prototype.findValue = function (value, equals, index) {
     return -1;
 };
 
+// TODO remove in v6 (not present in v2)
 Deque.prototype.findLast = function () {
-    deprecatedWarn('.findLast function is deprecated please use findLastValue instead.');
+    deprecatedWarn('Deque#findLast function is deprecated please use Deque#findLastValue instead.');
     return this.findLastValue.apply(this, arguments);
 };
 

--- a/shim-array.js
+++ b/shim-array.js
@@ -53,6 +53,14 @@ Array.unzip = function (table) {
 };
 
 function define(key, value) {
+
+    if (Array.prototype.hasOwnProperty(key)) {
+        if (typeof console.warn === 'function') {
+            console.warn('Overrided Array.prototype.' + key, "Saved into _" + key);
+        }
+        define("_" + key, Object.getOwnPropertyDescriptor(Array.prototype, key).value);
+    }
+
     Object.defineProperty(Array.prototype, key, {
         value: value,
         writable: true,
@@ -86,13 +94,13 @@ define("constructClone", function (values) {
 });
 
 define("has", function (value, equals) {
-    return this.find(value, equals) !== -1;
+    return this.findValue(value, equals) !== -1;
 });
 
 define("get", function (index, defaultValue) {
-    if (+index !== index)
+    if (+index !== index) {
         throw new Error("Indicies must be numbers");
-    if (!index in this) {
+    } else if (!index in this) {
         return defaultValue;
     } else {
         return this[index];
@@ -110,7 +118,7 @@ define("add", function (value) {
 });
 
 define("delete", function (value, equals) {
-    var index = this.find(value, equals);
+    var index = this.findValue(value, equals);
     if (index !== -1) {
         this.spliceOne(index);
         return true;
@@ -132,7 +140,20 @@ define("deleteAll", function (value, equals) {
     return count;
 });
 
+// https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
 define("find", function (value, equals) {
+    if (typeof arguments[0] === 'function' && this instanceof Array) {
+        return Array.prototype._find.apply(this, arguments);
+    } else {
+        if (typeof console.warn === 'function') {
+            console.warn('This find() usage is deprecated please use findValue()');
+        }
+        return Array.prototype.findValue.apply(this, arguments);
+    }
+});
+
+
+define("findValue", function (value, equals) {
     equals = equals || this.contentEquals || Object.equals;
     for (var index = 0; index < this.length; index++) {
         if (index in this && equals(value, this[index])) {
@@ -143,6 +164,13 @@ define("find", function (value, equals) {
 });
 
 define("findLast", function (value, equals) {
+    if (typeof console.warn === 'function') {
+        console.warn('.findLast function is deprecated please use findLastValue instead.');
+    }  
+    return Array.prototype.findLastValue.apply(this, arguments);
+});
+
+define("findLastValue", function (value, equals) {
     equals = equals || this.contentEquals || Object.equals;
     var index = this.length;
     do {
@@ -358,7 +386,8 @@ function ArrayIterator(array, start, end) {
     this.array = array;
     this.start = start == null ? 0 : start;
     this.end = end;
-};
+}
+
 ArrayIterator.prototype.__iterationObject = null;
 Object.defineProperty(ArrayIterator.prototype,"_iterationObject", {
     get: function() {

--- a/sorted-array.js
+++ b/sorted-array.js
@@ -199,6 +199,16 @@ SortedArray.prototype.lastIndexOf = function (value) {
 };
 
 SortedArray.prototype.find = function (value, equals, index) {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function'
+    ) {
+        console.warn('This find() usage is deprecated please use findValue()');
+    }
+    return SortedArray.prototype.findValue.apply(this, arguments);
+};
+
+SortedArray.prototype.findValue = function (value, equals, index) {
     // TODO throw error if provided a start index
     if (equals) {
         throw new Error("SortedArray#find does not support second argument: equals");
@@ -211,6 +221,16 @@ SortedArray.prototype.find = function (value, equals, index) {
 };
 
 SortedArray.prototype.findLast = function (value, equals, index) {
+    if (
+        typeof console !== 'undefined' &&
+            typeof console.warn === 'function'
+    ) {
+        console.warn('This findLast() usage is deprecated please use findLastValue()');
+    }
+    return SortedArray.prototype.findLastValue.apply(this, arguments);
+};
+
+SortedArray.prototype.findLastValue = function (value, equals, index) {
     if (equals) {
         throw new Error("SortedArray#findLast does not support second argument: equals");
     }

--- a/sorted-array.js
+++ b/sorted-array.js
@@ -198,44 +198,48 @@ SortedArray.prototype.lastIndexOf = function (value) {
     return searchLast(this.array, value, this.contentCompare, this.contentEquals);
 };
 
-SortedArray.prototype.find = function (value, equals, index) {
+var deprecatedWarnNonce = {};
+function deprecatedWarn(msg, notOnce) {
     if (
         typeof console !== 'undefined' &&
-            typeof console.warn === 'function'
+            typeof console.warn === 'function' &&
+                (notOnce !== true && deprecatedWarnNonce.hasOwnProperty(msg) === false)
     ) {
-        console.warn('This find() usage is deprecated please use findValue()');
+        console.warn(msg);
+        deprecatedWarnNonce[msg]++;
     }
-    return SortedArray.prototype.findValue.apply(this, arguments);
+}
+
+// TODO remove in v6 (not present in v2)
+SortedArray.prototype.find = function (value, equals, index) {
+    deprecatedWarn('This SortedArray#find usage is deprecated please use SortedArray#findValue');
+    return this.findValue.apply(this, arguments);
 };
 
 SortedArray.prototype.findValue = function (value, equals, index) {
     // TODO throw error if provided a start index
     if (equals) {
-        throw new Error("SortedArray#find does not support second argument: equals");
+        throw new Error("SortedArray#findValue does not support second argument: equals");
     }
     if (index) {
-        throw new Error("SortedArray#find does not support third argument: index");
+        throw new Error("SortedArray#findValue does not support third argument: index");
     }
     // TODO support initial partition index
     return searchFirst(this.array, value, this.contentCompare, this.contentEquals);
 };
 
+// TODO remove in v6 (not present in v2)
 SortedArray.prototype.findLast = function (value, equals, index) {
-    if (
-        typeof console !== 'undefined' &&
-            typeof console.warn === 'function'
-    ) {
-        console.warn('This findLast() usage is deprecated please use findLastValue()');
-    }
-    return SortedArray.prototype.findLastValue.apply(this, arguments);
+    deprecatedWarn('This SortedArray#findLast usage is deprecated please use SortedArray#findLastValue');
+    return this.findLastValue.apply(this, arguments);
 };
 
 SortedArray.prototype.findLastValue = function (value, equals, index) {
     if (equals) {
-        throw new Error("SortedArray#findLast does not support second argument: equals");
+        throw new Error("SortedArray#findLastValue does not support second argument: equals");
     }
     if (index) {
-        throw new Error("SortedArray#findLast does not support third argument: index");
+        throw new Error("SortedArray#findLastValue does not support third argument: index");
     }
     // TODO support initial partition index
     return searchLast(this.array, value, this.contentCompare, this.contentEquals);

--- a/test/spec/array-spec.js
+++ b/test/spec/array-spec.js
@@ -75,17 +75,45 @@ describe("Array-spec", function () {
 
     describe("find", function () {
 
-        it("should find equivalent objects", function () {
-            expect([{a:10}].find({a:10})).toEqual(0);
+        it("should find an object in an array by one of its properties", function () {
+            var inventory = [
+                {name: 'apples', quantity: 2},
+                {name: 'bananas', quantity: 0},
+                {name: 'cherries', quantity: 5}
+            ];
+
+            function isCherries(fruit) { 
+                return fruit.name === 'cherries';
+            }
+
+            expect(inventory.find(isCherries)).toEqual(inventory[2]);
         });
 
-        it("should allow equality comparison override", function () {
-            expect([{a:10}].find({a:10}, Object.is)).toEqual(-1);
+        describe("find (deprecated support)", function () {
+
+            it("should find equivalent objects", function () {
+                expect([{a:10}].find({a:10})).toEqual(0);
+            });
+
+            it("should allow equality comparison override", function () {
+                expect([{a:10}].find({a:10}, Object.is)).toEqual(-1);
+            });
         });
 
     });
 
-    describe("findLast", function () {
+    describe("findValue", function () {
+
+        it("should find equivalent objects", function () {
+            expect([{a:10}].findValue({a:10})).toEqual(0);
+        });
+
+        it("should allow equality comparison override", function () {
+            expect([{a:10}].findValue({a:10}, Object.is)).toEqual(-1);
+        });
+    });
+
+    describe("findLast (deprecated support)", function () {
 
         it("should find equivalent objects", function () {
             expect([{a:10}].findLast({a:10})).toEqual(0);
@@ -98,6 +126,23 @@ describe("Array-spec", function () {
         it("should find the last of equivalent objects", function () {
             var object = {a: 10};
             expect([object, {a: 10}].findLast(object)).toEqual(1);
+        });
+
+    });
+
+    describe("findLastValue", function () {
+
+        it("should find equivalent objects", function () {
+            expect([{a:10}].findLastValue({a:10})).toEqual(0);
+        });
+
+        it("should allow equality comparison override", function () {
+            expect([{a:10}].findLastValue({a:10}, Object.is)).toEqual(-1);
+        });
+
+        it("should find the last of equivalent objects", function () {
+            var object = {a: 10};
+            expect([object, {a: 10}].findLastValue(object)).toEqual(1);
         });
 
     });

--- a/test/spec/order.js
+++ b/test/spec/order.js
@@ -147,7 +147,7 @@ function describeOrder(Collection) {
 
     });
 
-    describe("find", function () {
+    describe("find (deprecated support)", function () {
 
         it("finds equivalent values", function () {
             expect(Collection([10, 10, 10]).find(10)).toEqual(0);
@@ -159,10 +159,29 @@ function describeOrder(Collection) {
 
     });
 
-    describe("findLast", function () {
+    describe("findValue", function () {
+
+        it("finds equivalent values", function () {
+            expect(Collection([10, 10, 10]).findValue(10)).toEqual(0);
+        });
+
+        it("finds equivalent values", function () {
+            expect(Collection([10, 10, 10]).findValue(10)).toEqual(0);
+        });
+
+    });
+
+    describe("findLast (deprecated support)", function () {
 
         it("finds equivalent values", function () {
             expect(Collection([10, 10, 10]).findLast(10)).toEqual(2);
+        });
+    });
+
+    describe("findLastValue", function () {
+
+        it("finds equivalent values", function () {
+            expect(Collection([10, 10, 10]).findLastValue(10)).toEqual(2);
         });
 
     });


### PR DESCRIPTION
- [x] Deprecate find() in favor of findValue()
- [x] Deprecate findLast() in favor of findLastValue()
- [x] Add console warning
- [x] Detect legacy usage and display warning
- [x] Add ES6 Array.prototype.find shim when missing
- [x] Add ES6 Array.prototype.find basic spec


<img width="650" alt="screen shot 2017-12-07 at 8 48 36 am" src="https://user-images.githubusercontent.com/8635/33727102-ee5c849a-db2b-11e7-84ae-a1d24e6153b4.png">
