### PR TITLE
Add change dispatch to Set.size in polyfill

### DIFF
--- a/set.js
+++ b/set.js
@@ -179,6 +179,7 @@ function setupCollectionSet() {
         if (!this.store.has(node)) {
             var index = this.length;
             var dispatchValueArray = [value];
+            this.dispatchBeforeOwnPropertyChange(SIZE, index);
             if (this.dispatchesRangeChanges) {
                 this.dispatchBeforeRangeChange(dispatchValueArray, this._dispatchEmptyArray, index);
             }
@@ -189,6 +190,7 @@ function setupCollectionSet() {
             if (this.dispatchesRangeChanges) {
                 this.dispatchRangeChange(dispatchValueArray, this._dispatchEmptyArray, index);
             }
+            this.dispatchOwnPropertyChange(SIZE, index + 1);
             return true;
         }
         return false;
@@ -201,6 +203,7 @@ function setupCollectionSet() {
         if (this.store.has(node)) {
             node = this.store.get(node);
             var dispatchValueArray = [value];
+            this.dispatchBeforeOwnPropertyChange(SIZE, this.length);
             if (this.dispatchesRangeChanges) {
                 this.dispatchBeforeRangeChange(this._dispatchEmptyArray, dispatchValueArray, node.index);
             }
@@ -210,12 +213,17 @@ function setupCollectionSet() {
             if (this.dispatchesRangeChanges) {
                 this.dispatchRangeChange(this._dispatchEmptyArray, dispatchValueArray, node.index);
             }
+            this.dispatchOwnPropertyChange(SIZE, this.length);
             return true;
         }
         return false;
     };
     CollectionsSet.prototype.clear = function () {
         var clearing;
+        var length = this.length;
+        if (length) {
+            this.dispatchBeforeOwnPropertyChange(SIZE, length);
+        }
         if (this.dispatchesRangeChanges) {
             clearing = this.toArray();
             this.dispatchBeforeRangeChange(this._dispatchEmptyArray, clearing, 0);
@@ -223,6 +231,9 @@ function setupCollectionSet() {
         this._clear();
         if (this.dispatchesRangeChanges) {
             this.dispatchRangeChange(this._dispatchEmptyArray, clearing, 0);
+        }
+        if (length) {
+            this.dispatchOwnPropertyChange(SIZE, 0);
         }
     };
 
@@ -232,7 +243,7 @@ function setupCollectionSet() {
         this.order.makeObservable();
     };
 
-    module.exports = CollectionsSet
+    module.exports = CollectionsSet;
 }
 
 

--- a/test/spec/set-spec.js
+++ b/test/spec/set-spec.js
@@ -3,8 +3,10 @@ var Set = require("collections/set");
 var describeCollection = require("./collection");
 var describeSet = require("./set");
 
-Set._setupCollectionSet();
-var CollectionsSet = Set.CollectionsSet;
+if (Set._setupCollectionSet) {
+    Set._setupCollectionSet();
+}
+var CollectionsSet = Set.CollectionsSet || Set;
 
 describe("CollectionsSet-spec", function () {
     var Set = CollectionsSet;
@@ -180,8 +182,8 @@ describe("Set-spec", function () {
     });
 
     it("should dispatch size property change on clear", function () {
-        // var set = new Set([1, 2, 3]);
-        var set = Set.from([1, 2, 3]);
+        var set = new Set([1, 2, 3]);
+        // var set = Set.from([1, 2, 3]);
         var spy = jasmine.createSpy();
         set.addBeforeOwnPropertyChangeListener("size", function (size) {
             spy("size change from", size);
@@ -191,9 +193,15 @@ describe("Set-spec", function () {
             spy("size change to", size);
         });
 
-        expect(set).toEqual(new Set([1, 2, 3]));
+        expect(set.size).toBe(3);
+        expect(set.has(1)).toBe(true);
+        expect(set.has(2)).toBe(true);
+        expect(set.has(3)).toBe(true);
         set.clear();
-        expect(set).toEqual(new Set());
+        expect(set.size).toBe(0);
+        expect(set.has(1)).toBe(false);
+        expect(set.has(2)).toBe(false);
+        expect(set.has(3)).toBe(false);
         
         var argsForCall = spy.calls.all().map(function (call) { return call.args });
         expect(argsForCall).toEqual([


### PR DESCRIPTION
This PR propagates the changes in https://github.com/montagejs/collections/pull/216 to the `CollectionsSet` class. This is necessary for `Set.size` to be observable in in IE version <= 11. 