### PR TITLE
Adjust Symbol null check in shim-array

### DIFF
--- a/shim-array.js
+++ b/shim-array.js
@@ -25,8 +25,9 @@ if (Object.freeze) {
 
 Array.nativeFrom = Array.from;
 
+var isSymbolDefined = typeof Symbol !== "undefined";
 Array.from = function (values, mapFn, thisArg) {
-    if(Symbol && values && typeof values[Symbol.iterator] === "function") {
+    if (isSymbolDefined && values && typeof values[Symbol.iterator] === "function") {
         return Array.nativeFrom(values, mapFn, thisArg);
     }
     //Now we add support for values that implement forEach:


### PR DESCRIPTION
@marchant The previous check ( `if (Symbol....` ) fails on IE11 because Symbol is not defined. This PR changes the null check to use `typeof` instead. 


![Screen Shot 2020-04-15 at 1 18 57 PM](https://user-images.githubusercontent.com/10407370/79384470-c853c880-7f1b-11ea-9796-328ef6e4b4ea.png)

